### PR TITLE
Fix OptimizationTrace constructor according to Optim v0.6

### DIFF
--- a/src/estimate/csminwel.jl
+++ b/src/estimate/csminwel.jl
@@ -121,7 +121,7 @@ function csminwel(fcn::Function,
     iteration = 0
 
     # Maintain a trace
-    tr = OptimizationTrace(Csminwel())
+    tr = OptimizationTrace{Csminwel}()
     tracing = show_trace || store_trace || extended_trace
     @csminwelltrace
 


### PR DESCRIPTION
Sorry for breaking your tests, but this should fix it. We could have kept the old syntax if Julia v0.5 was live - oh well.