### PR TITLE
seed explicitly MersenneTwister(0)

### DIFF
--- a/src/estimate/csminwel.jl
+++ b/src/estimate/csminwel.jl
@@ -42,7 +42,7 @@ end
 csminwel(fcn::Function, grad::Function, x0::Vector, H0::Matrix=1e-5.*eye(length(x0)), args...;
          xtol::Real=1e-32, ftol::Float64=1e-14, grtol::Real=1e-8, iterations::Int=1000,
          store_trace::Bool = false, show_trace::Bool = false, extended_trace::Bool = false,
-         verbose::Symbol = :none, rng::AbstractRNG = MersenneTwister(), kwargs...)
+         verbose::Symbol = :none, rng::AbstractRNG = MersenneTwister(0), kwargs...)
 ```
 
 Minimizes `fcn` using the csminwel algorithm.
@@ -84,7 +84,7 @@ function csminwel(fcn::Function,
                   show_trace::Bool     = false,
                   extended_trace::Bool = false,
                   verbose::Symbol      = :none,
-                  rng::AbstractRNG     = MersenneTwister(),
+                  rng::AbstractRNG     = MersenneTwister(0),
                   kwargs...)
 
     if show_trace
@@ -346,7 +346,7 @@ function csminwel(fcn::Function,
                   show_trace::Bool     = false,
                   extended_trace::Bool = false,
                   verbose::Symbol      = :none,
-                  rng::AbstractRNG     = MersenneTwister(),
+                  rng::AbstractRNG     = MersenneTwister(0),
                   kwargs...)
 
     grad{T<:Number}(x::Array{T}) = csminwell_grad(fcn, x, args...; kwargs...)

--- a/src/models/m1002/m1002.jl
+++ b/src/models/m1002/m1002.jl
@@ -179,7 +179,7 @@ function Model1002(subspec::AbstractString="ss2")
     subspec            = subspec
     settings           = Dict{Symbol,Setting}()
     test_settings      = Dict{Symbol,Setting}()
-    rng                = MersenneTwister()
+    rng                = MersenneTwister(0)
     testing            = false
 
     # Set up data sources and series

--- a/src/models/m990/m990.jl
+++ b/src/models/m990/m990.jl
@@ -176,7 +176,7 @@ function Model990(subspec::AbstractString="ss2")
     subspec            = subspec
     settings           = Dict{Symbol,Setting}()
     test_settings      = Dict{Symbol,Setting}()
-    rng                = MersenneTwister()
+    rng                = MersenneTwister(0)
     testing            = false
 
     # Set up data sources and series
@@ -187,7 +187,7 @@ function Model990(subspec::AbstractString="ss2")
     fernald_series     = [:TFPJQ, :TFPKQ]
     longrate_series    = [:FYCZZA]
     # ois data taken care of in load_data
-    
+
     data_series = Dict{Symbol,Vector{Symbol}}(:fred => fred_series, :spf => spf_series,
                                               :fernald => fernald_series, :longrate => longrate_series)
 
@@ -787,7 +787,7 @@ function init_data_transforms!(m::Model990)
     for i = 1:n_anticipated_shocks(m)
         # FROM: OIS expectations of $i-period-ahead interest rates at a quarterly rate
         # TO:   Same
-        
+
         m.data_transforms[symbol("obs_ois$i")] = function (levels)
             levels[:, symbol("ant$i")]
         end

--- a/src/models/smets_wouters/smets_wouters.jl
+++ b/src/models/smets_wouters/smets_wouters.jl
@@ -167,7 +167,7 @@ function SmetsWouters(subspec::AbstractString="ss0")
     subspec            = subspec
     settings           = Dict{Symbol,Setting}()
     test_settings      = Dict{Symbol,Setting}()
-    rng                = MersenneTwister()        # Random Number Generator
+    rng                = MersenneTwister(0)        # Random Number Generator
     testing            = false
 
     # initialize empty model


### PR DESCRIPTION
The default constructor `MersenneTwister()` will be deprecated, cf. https://github.com/JuliaLang/julia/pull/16984#issuecomment-290914407.