### PR TITLE
README.md: Fixed typo (2.0.0 -> 0.2.0) under Versioning and added local tag checkout instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ julia> Pkg.add("DSGE")
 # Versioning
 
 To use `DSGE.jl` with Julia version 0.4, please check out tag
-2.0.0. To do this, click on the drop-down menu that reads `branch:
+0.2.0. To do this, click on the drop-down menu that reads `branch:
 master` on the left-hand side of the page. Select `tags`, then
-`v0.2.0`.
+`v0.2.0`.  If you've already cloned the repo, you can simply run
+`git checkout v0.2.0`.


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>