### PR TITLE
Metropolis-Hastings jump size

### DIFF
--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -97,6 +97,10 @@ function default_settings!(m::AbstractModel)
         "Number of blocks to use as burn-in in Metropolis-Hastings")
     settings[:mh_thin] = Setting(:mh_thin, 5,
         "Metropolis-Hastings thinning step")
+    settings[:mh_cc] = Setting(:mh_cc, 0.09,
+        "Jump size for Metropolis-Hastings (after initialization)")
+    settings[:mh_cc0] = Setting(:mh_cc0, 0.01,
+        "Jump size for initialization of Metropolis-Hastings")
 
     # Forecast
     settings[:forecast_block_size] = Setting(:forecast_block_size, 5000,

--- a/src/estimate/estimate.jl
+++ b/src/estimate/estimate.jl
@@ -184,8 +184,8 @@ function estimate(m::AbstractModel, data::Matrix{Float64};
     ########################################################################################
 
     # Set the jump size for sampling
-    cc0 = 0.01
-    cc = 0.09
+    cc0 = get_setting(m, :mh_cc0)
+    cc = get_setting(m, :mh_cc)
 
     metropolis_hastings(propdist, m, data, cc0, cc; verbose=verbose)
 

--- a/src/models/an_schorfheide/an_schorfheide.jl
+++ b/src/models/an_schorfheide/an_schorfheide.jl
@@ -287,6 +287,10 @@ function settings_an_schorfheide!(m::AnSchorfheide)
     m <= Setting(:cond_semi_names, [:obs_nominalrate],
         "Observables used in semiconditional forecasts")
 
+    # Metropolis-Hastings
+    m <= Setting(:mh_cc, 0.27,
+                 "Jump size for Metropolis-Hastings (after initialization)")
+
     # Forecast
     m <= Setting(:use_population_forecast, true,
                  "Whether to use population forecasts as data")


### PR DESCRIPTION
I added settings to change the scaling factor on the proposal covariance matrix (called `mh_cc` and `mh_cc0`). 

Defaults are set at the values in the original code. However, I overrode them for `AnSchorfheide` so that now it gives rejection rates around 67%.