### PR TITLE
fix for forecast dims and chunk_dims swapped

### DIFF
--- a/src/forecast/io.jl
+++ b/src/forecast/io.jl
@@ -224,10 +224,10 @@ function write_forecast_outputs(m::AbstractDSGEModel, input_type::Symbol,
                     # all draws
                     if !isnull(block_number) && get(block_number) == 1
                         # Determine forecast output size
-                        dims  = get_forecast_output_dims(m, input_type, var; subset_inds = subset_inds)
+                        dims  = collect(get_forecast_output_dims(m, input_type, var; subset_inds = subset_inds))
                         block_size = forecast_block_size(m)
-                        chunk_dims = collect(dims)
-                        chunk_dims[1] = block_size
+                        chunk_dims = copy(dims)
+                        dims[1] = block_size
 
                         # Initialize dataset
                         #pfile = file #.plain


### PR DESCRIPTION
The `forecast_one` function is failing when trying to write the results to HDF5. The dataspace dimensions and the chunk dimension were around the wrong way, which throws a write exception. Specifically, line 230 was the issue where `chunk_dims[1] = block_size`.

