### PR TITLE
fixed a bug in steady state Labor

### DIFF
--- a/src/models/representative/m1002/m1002.jl
+++ b/src/models/representative/m1002/m1002.jl
@@ -503,7 +503,7 @@ function init_parameters!(m::Model1002)
 
     # standard deviations of the anticipated policy shocks
     for i = 1:n_anticipated_shocks_padding(m)
-        if i < 13
+        if i <= n_anticipated_shocks(m)
             m <= parameter(Symbol("σ_r_m$i"), .2, (1e-7, 100.), (1e-5, 0.), ModelConstructors.Exponential(), RootInverseGamma(4, .2), fixed=false,
                            description="σ_r_m$i: Standard deviation of the $i-period-ahead anticipated policy shock.",
                            tex_label=@sprintf("\\sigma_{ant%d}",i))
@@ -583,7 +583,8 @@ function steadystate!(m::Model1002)
     m[:Rstarn]   = 100*(m[:rstar]*m[:π_star] - 1)
     m[:r_k_star] = m[:spr]*m[:rstar]*m[:Upsilon] - (1-m[:δ])
     m[:wstar]    = (m[:α]^m[:α] * (1-m[:α])^(1-m[:α]) * m[:r_k_star]^(-m[:α]) / m[:Φ])^(1/(1-m[:α]))
-    m[:Lstar]    = 1.
+    m[:Lstar]    = (m[:wstar]/m[:λ_w]/((1-m[:g_star])*(m[:α]/(1-m[:α])*m[:wstar]/m[:r_k_star])^m[:α]/m[:Φ]-
+     (1-(1-m[:δ])/m[:Upsilon]*exp(-m[:z_star]))*m[:Upsilon]*exp(m[:z_star])*m[:α]/(1-m[:α])*m[:wstar]/m[:r_k_star])/(1-m[:h]*exp(-m[:z_star])))^(1/(1+m[:ν_l]))
     m[:kstar]    = (m[:α]/(1-m[:α])) * m[:wstar] * m[:Lstar] / m[:r_k_star]
     m[:kbarstar] = m[:kstar] * (1+m[:γ]) * m[:Upsilon]^(1 / (1-m[:α]))
     m[:istar]    = m[:kbarstar] * (1-((1-m[:δ])/((1+m[:γ]) * m[:Upsilon]^(1/(1-m[:α])))))


### PR DESCRIPTION
Labor can not be normalized to one as in Smet Wouters because SW do not use the parameter phi, which would make FOC hold for any Lstar. See the note to equation 8.53 on page 58 of the technical appendix at https://web.sas.upenn.edu/schorf/files/2017/04/hb_forecasting_appendix-1jhkhvj.pdf