### PR TITLE
fixed bug in wage Phillips curve

### DIFF
--- a/src/models/representative/m1002/eqcond.jl
+++ b/src/models/representative/m1002/eqcond.jl
@@ -122,6 +122,7 @@ function eqcond(m::Model1002)
 
     # Flexible prices and wages
     Γ0[eq[:eq_nevol_f], endo[:n_f_t]]      = 1.
+    Γ0[eq[:eq_nevol_f], endo[:γ_t]]      = -1.
     Γ0[eq[:eq_nevol_f], endo[:z_t]]      = m[:γ_star]*m[:vstar]/m[:nstar]
     Γ0[eq[:eq_nevol_f], endo[:rktil_f_t]] = -m[:ζ_nRk]
     Γ1[eq[:eq_nevol_f], endo[:σ_ω_t]]    = -m[:ζ_nσ_ω]/m[:ζ_spσ_ω]
@@ -256,9 +257,10 @@ function eqcond(m::Model1002)
     Γ0[eq[:eq_wage], endo[:μ_ω_t]] = (1 - m[:ζ_w]*m[:β]*exp((1 - m[:σ_c])*m[:z_star]))*
         (1 - m[:ζ_w])/(m[:ζ_w]*((m[:λ_w] - 1)*m[:ϵ_w] + 1))/(1 + m[:β]*exp((1 - m[:σ_c])*m[:z_star]))
     Γ0[eq[:eq_wage], endo[:π_t]]   = (1 + m[:ι_w]*m[:β]*exp((1 - m[:σ_c])*m[:z_star]))/(1 + m[:β]*exp((1 - m[:σ_c])*m[:z_star]))
+    Γ0[eq[:eq_wage], endo[:z_t]]   = (1 + m[:ι_w]*m[:β]*exp((1 - m[:σ_c])*m[:z_star]))/(1 + m[:β]*exp((1 - m[:σ_c])*m[:z_star])) # BUG FIXED -- TERM CORRECTED ON 9/15/16
     Γ1[eq[:eq_wage], endo[:w_t]]   = 1/(1 + m[:β]*exp((1 - m[:σ_c])*m[:z_star]))
-    Γ0[eq[:eq_wage], endo[:z_t]]   = 1/(1 + m[:β]*exp((1 - m[:σ_c])*m[:z_star]))
     Γ1[eq[:eq_wage], endo[:π_t]]   = m[:ι_w]/(1 + m[:β]*exp((1 - m[:σ_c])*m[:z_star]))
+    Γ1[eq[:eq_wage], endo[:z_t]]   = m[:ι_w]/(1 + m[:β]*exp((1 - m[:σ_c])*m[:z_star])) # BUG FIXED -- TERM ADDED ON 9/15/16
     Γ0[eq[:eq_wage], endo[:Ew_t]]  = -m[:β]*exp((1 - m[:σ_c])*m[:z_star])/(1 + m[:β]*exp((1 - m[:σ_c])*m[:z_star]))
     Γ0[eq[:eq_wage], endo[:Ez_t]]  = -m[:β]*exp((1 - m[:σ_c])*m[:z_star])/(1 + m[:β]*exp((1 - m[:σ_c])*m[:z_star]))
     Γ0[eq[:eq_wage], endo[:Eπ_t]]  = -m[:β]*exp((1 - m[:σ_c])*m[:z_star])/(1 + m[:β]*exp((1 - m[:σ_c])*m[:z_star]))


### PR DESCRIPTION
I think the term z_{t-1} is missing and coefficient for term z_t is incorrect in the Phillips curve for wages.
If we take the wage Phillips curve in Smets Wouters 2007 (page 6, equation 13) and replace pi_t with pi_t+z_t then we don't get the same equation as equation 14 in Chapter 2 of DSGE Model-Based Forecasting in Handbook of Economic Forecasting (which is also equation 8.106 derived incorrectly in the technical appendix).

The second bug is in the evolution of net worth in flexible economy. The term gamma_t is missing.